### PR TITLE
Simplify setup instructions

### DIFF
--- a/Setup Instructions.md
+++ b/Setup Instructions.md
@@ -8,33 +8,20 @@
 
    ![Drag to Applications](https://github.com/amaheshwari01/Key-Finder/assets/68670569/12a34ed3-30d9-4782-ae05-456b86ea8205)
 
-3. Close the window and open the Key Finder app.
-
-4. If you encounter an that says that the developer is not verified this is because i am not paying 100 dollars to apple 
- 
-
- 
-
-     ![Privacy & Security](https://github.com/amaheshwari01/Key-Finder/assets/68670569/43d47b89-f063-46da-a422-c276213a8ed9)
-
-5. CLICK CANCEL
-6. Go to System Settings -> Privacy & Security. Scroll down to the section that appears.
-
-
-7. Click "Open Anyway", enter your password, and click "Open".
-
-8. You will be greeted with a login screen with Google. Log in and grant access to PowerSchool.
-
-9. You should see the following screen.
+3. Close the window. Right click the "Key Finder" app and click open.
+4. You'll receive a prompt that asks you to "Open" or "Move to Trash."
+5. Click "Open."
+6. You will be greeted with a login screen with Google. Log in and grant access to PowerSchool.
+7. You should see the following screen.
 
    ![Login Screen](https://github.com/amaheshwari01/Key-Finder/assets/68670569/146d0ec1-d980-418b-bf1e-2735417909aa)
 
-10. It should automatically copy a token to your clipboard
+8. It should automatically copy a token to your clipboard
 
-11. Visit [POWERSCRAPER](https://power.aayanmaheshwari.com) and paste the code you got.
+9. Visit [POWERSCRAPER](https://power.aayanmaheshwari.com) and paste the code you got.
 
 <img width="438" alt="SCR-20231215-qkvx" src="https://github.com/amaheshwari01/Key-Finder/assets/68670569/48087028-0367-46aa-bb90-1bf97e564071">
 
-13. You are now set up and ready to use the app.
+8. You are now set up and ready to use the app.
 
 For Usage instructions, refer to the [Usage Guide](https://github.com/amaheshwari01/Power-Assist/blob/main/UsageGuide.md).


### PR DESCRIPTION
This PR simplifies setup instructions by telling people to right-click on the downloaded app, and opening it from there, which opens a separate prompt that allows you to open it from there.